### PR TITLE
Fix distributor doesn't remove old directory with broken link.

### DIFF
--- a/pulp_katello/distributors/yum_clone_distributor/distributor.py
+++ b/pulp_katello/distributors/yum_clone_distributor/distributor.py
@@ -161,7 +161,7 @@ class YumCloneDistributor(Distributor):
     def link_directory(self, source, destination):
         try:
             destination = destination.rstrip('/')
-            if os.path.exists(destination):
+            if os.path.lexists(destination):
                 os.unlink(destination)
             base_path = os.path.split(destination)[0]
             if not os.path.exists(base_path):


### PR DESCRIPTION
"/var/lib/pulp/published/yum/https/repos/ORG/ENV/CV/content/dist/rhel/server/7/7Server/x86_64/os/" is linked to "/var/lib/pulp/published/yum/master/yum_distributor/<repo_id>/<timstamp>". If somehow this timestamp directory is missing (broken link), the "yum_clone_distributor" will not delete it while publishing the repo. This will cause the following error.

  Exception: Failed to link metadata.  See errors for more details.
spawned_tasks: []
progress_report:
    <repo_id>_clone:
      errors:
      - File exists

To fix this issue we can replace the "os.path.exists" with "os.path.lexists". "os.path.exists" will return False if the link is broken. "os.path.lexists" will return True even if the link is broken.